### PR TITLE
Add common actions and workflows.

### DIFF
--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -1,0 +1,31 @@
+name: 'Initialize'
+description: 'Checkout repo and install dependencies'
+inputs:
+  latest:
+    description: 'If true, ignore requirements.txt and the versions pinned there.'
+    default: 'false'
+  documentation:
+    description: 'If true, install documentation build frameworks.'
+    default: 'false'
+runs:
+  using: "composite"
+  steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+      shell: bash
+    - name: Install minimum-version runtime dependencies + GEMD
+      run: python -m pip install --only-binary ':all:' -r requirements.txt
+      shell: bash
+      if: ${{ inputs.latest == 'false' }}
+    - name: Install test dependencies
+      run: python -m pip install --only-binary ':all:' -r test_requirements.txt
+      shell: bash
+    - name: Install documentation building framework
+      run: python -m pip install --only-binary ':all:' -r doc_requirements.txt
+      shell: bash
+      if: ${{ inputs.documentation == 'true' }}
+    - name: Install gemd-python, along with the latest version of any outstanding dependencies
+      run: python -m pip install --only-binary ':all:' -e .
+      shell: bash

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,41 @@
+name: Build and Deploy Docs
+
+on:
+  workflow_call:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+        with:
+          documentation: 'true'
+      - name: Build Docs
+        run: |
+            make -C docs/ html
+            touch docs/_build/html/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/_build/html'
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy to PyPI
+
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    name: Publish package to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Build
+        run: python setup.py sdist bdist_wheel
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -1,0 +1,46 @@
+name: PR Checks
+
+on:
+  workflow_call:
+    inputs:
+      src:
+        description: 'The path to the source directory.'
+        required: true
+        type: string
+
+jobs:
+  check-version:
+    name: Check version bumped
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+      - name: Check version
+        run: python scripts/validate_version_bump.py
+  linting:
+    name: Run linting with flake8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+      - name: Lint the source directory
+        run: flake8 ${{ inputs.src }}
+  check-deprecated:
+    name: Find code marked for removal in this version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+      - name: Deprecated check
+        run: derp . ${{ inputs.src }}/__version__.py
+  check-docs:
+    name: Check docs for warnings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+        with:
+          documentation: 'true'
+      - name: Build Docs
+        continue-on-error: true
+        run: make -C docs/ html SPHINXOPTS='-W --keep-going'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,49 @@
+name: PR Tests
+
+on:
+  workflow_call:
+    inputs:
+      src:
+        description: 'The path to the source directory.'
+        required: true
+        type: string
+
+
+jobs:
+  run-tests:
+    name: Execute unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+      - name: Execute unit tests
+        run: pytest --cov=${{ inputs.src }} --cov-report term-missing:skip-covered --cov-config=tox.ini --no-cov-on-fail --cov-fail-under=100  tests/
+  run-tests-against-latest:
+    # These runs are intended to confirm the latest minor version of our dependencies we claim to
+    # support don't break with our latest changes. Since they're not the versions we directly state
+    # you should use (i.e. in requirements.txt), they arguably aren't critical, hence not blocking.
+    name: Non-blocking - Execute unit tests against latest version of dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Initialize the environment
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
+        with:
+          latest: 'true'
+      - name: Execute unit tests
+        run: pytest tests/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+This is intended to store the GitHub Actions workflows and actions which are shared by Citrine's public Python repos.
+
+## Actions
+
+### Intialize
+
+Sets up the environment in which it's being run. Upgrades pip and installs all dependencies, including the calling repo itself.
+
+#### inputs
+
+- latest: if true, skips installing requirements.txt, instead relying on what's defined in the caller's setup.py install\_requires.
+
+- documentation: if true, also installs the doc\_requirements.txt file.
+
+## Workflows
+
+### Repo Checks (repo-checks.yml)
+
+Kicks off four jobs to perform standard repo checks. Namely:
+
+- linting, using `flake8`,
+- checks that the version number in <src>/\_\_version\_\_.py was bumped
+- looks for code marked deprecated, using `derp`
+- confirms the docs build doesn't throw any warnings
+
+#### inputs
+
+- src: The directory containing the repo's source code.
+
+### Run Tests (run-tests.yml)
+
+Runs the repo's tests against every supported Python version. It also kicks off a second run of tests in an environment where the dependency versions are the latest supported, instead of what's in requirements.txt.
+
+#### inputs
+
+- src: The directory containing the repo's source code.
+
+### Deploy Documentation (deploy-docs.yml)
+
+Build and deploy the docs using GitHub Pages.
+
+### Deploy to PyPI (deploy.yml)
+
+Package the code and deploy it to PyPI. This requires you have an action secret defined called `PYPI_API_TOKEN`.


### PR DESCRIPTION
The initial set of actions and workflows. These are mostly grabbed from [gemd-python](https://github.com/CitrineInformatics/gemd-python/tree/main/.github), with a couple tweaks to make them parameterizable.

Note that since workflows cannot accept lists as inputs, the python versions supported are hard-coded. To allow deploying with varied version lists and to avoid forcing all our packages to upgrade at once, we'll use GitHub tags to version the workflows.