### PR TITLE
Add MacOS and Windows servers to testing matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,14 @@ on:
 jobs:
   run-tests:
     name: Execute unit tests
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    runs-on: ${{ matrix.runner-os }}
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.runner-os }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -31,13 +32,14 @@ jobs:
     # support don't break with our latest changes. Since they're not the versions we directly state
     # you should use (i.e. in requirements.txt), they arguably aren't critical, hence not blocking.
     name: Non-blocking - Execute unit tests against latest version of dependencies
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    runs-on: ${{ matrix.runner-os }}
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.runner-os }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Kicks off four jobs to perform standard repo checks. Namely:
 
 ### Run Tests (run-tests.yml)
 
-Runs the repo's tests against every supported Python version. It also kicks off a second run of tests in an environment where the dependency versions are the latest supported, instead of what's in requirements.txt.
+Runs the repo's tests against every supported Python version and every supported OS.
+It also kicks off a second run of tests in an environment where the dependency versions are the latest supported, instead of what's in requirements.txt.
 
 #### inputs
 


### PR DESCRIPTION
Adds OS to testing matrix, so now libraries will be evaluated on the latest GitHub Actions runners for Windows & MacOS as well as ubuntu-latest.