### PR TITLE
Turn deploy into a template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ It also kicks off a second run of tests in an environment where the dependency v
 
 Build and deploy the docs using GitHub Pages.
 
-### Deploy to PyPI (deploy.yml)
+## Templates
+
+These are workflows which for whatever reason can't be shared. As such, we provide what it should look like in your repo.
+
+### Deploy to PyPI (deploy-template.yml)
 
 Package the code and deploy it to PyPI. This requires you have an action secret defined called `PYPI_API_TOKEN`.
+
+See https://github.com/pypi/warehouse/issues/11096 for details on why the PyPI deploy workflow cannot be shared.

--- a/deploy-template.yml
+++ b/deploy-template.yml
@@ -1,3 +1,10 @@
+# As noted in https://github.com/pypi/warehouse/issues/11096, the current
+# version of PyPI's GitHub Actions workflow uses the repo which calls it for
+# Trusted Publishing, meaning it doesn't support being called in a shared
+# workflow.
+# To use the common deploy workflow, copy the workflow below into your repo for
+# direct use. If/when they fix it, we'll update ASAP.
+
 name: Deploy to PyPI
 
 on:


### PR DESCRIPTION
The deploy workflow cannot be shared because the PyPI GitHub Action deploy workflow cannot be shared when using Trusted Publishers.

See https://github.com/pypi/warehouse/issues/11096