### PR TITLE
Bugfix: Python version matrix import

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,22 +23,23 @@ jobs:
   matrix-prep:
     runs-on: ubuntu-latest
     outputs:
-      python-version: ${{ steps.version-interpolator.outputs.python-version }}
+      versions: ${{ steps.interpolator.outputs.versions }}
     steps:
       - name: Determine Python versions to test
-        id: version-interpolator
+        id: interpolator
         run: |
           if [ ! ${{ inputs.skip_38 }} = true ]; then PY38='"3.8", '; else PY38=''; fi
           if [ ${{ inputs.include_313 }} = true ]; then PY313=', "3.13"'; else PY313=''; fi
-          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]\n' "$PY38" "$PY313" >> "$GITHUB_OUTPUT"
+          printf 'versions=[%s"3.9", "3.10", "3.11", "3.12"%s]\n' "$PY38" "$PY313" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+
   run-tests:
     name: Execute unit tests
     needs: matrix-prep
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
+        python-version: ${{ fromJson(needs.matrix-prep.outputs.versions) }}
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:
@@ -50,6 +51,7 @@ jobs:
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v1
       - name: Execute unit tests
         run: pytest --cov=${{ inputs.src }} --cov-report term-missing:skip-covered --cov-config=tox.ini --no-cov-on-fail --cov-fail-under=100  tests/
+
   run-tests-against-latest:
     # These runs are intended to confirm the latest minor version of our dependencies we claim to
     # support don't break with our latest changes. Since they're not the versions we directly state
@@ -59,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
+        python-version: ${{ fromJson(needs.matrix-prep.outputs.versions) }}
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           if [ ! ${{ inputs.skip_38 }} = true ]; then PY38='"3.8", '; else PY38=''; fi
           if [ ${{ inputs.include_313 }} = true ]; then PY313=', "3.13"'; else PY313=''; fi
-          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]' "$PY38" "$PY313" >> $GITHUB_OUTPUT
+          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]\n' "$PY38" "$PY313" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
   run-tests:
     name: Execute unit tests
     needs: matrix-prep

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,15 +7,37 @@ on:
         description: 'The path to the source directory.'
         required: true
         type: string
+      skip_38:
+        description: 'If true, skip running tests on Python 3.8.'
+        required: false
+        type: boolean
+        default: false
+      include_313:
+        description: 'If true, include Python 3.13 in the test matrix.'
+        required: false
+        type: boolean
+        default: false
 
 
 jobs:
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      python-version: ${{ steps.version-interpolator.outputs.python-version }}
+    steps:
+      - name: Determine Python versions to test
+      - id: version-interpolator
+        run: |
+          if [ ! ${{ inputs.skip_38 }} = true ]; then PY38='"3.8", '; else PY38=''; fi
+          if [ ${{ inputs.include_313 }} = true ]; then PY313='", 3.13"'; else PY313=''; fi
+          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]' $PY38 $PY313) >> $GITHUB_OUTPUT
   run-tests:
     name: Execute unit tests
+    needs: matrix-prep
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:
@@ -32,10 +54,11 @@ jobs:
     # support don't break with our latest changes. Since they're not the versions we directly state
     # you should use (i.e. in requirements.txt), they arguably aren't critical, hence not blocking.
     name: Non-blocking - Execute unit tests against latest version of dependencies
+    needs: matrix-prep
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,11 +26,11 @@ jobs:
       python-version: ${{ steps.version-interpolator.outputs.python-version }}
     steps:
       - name: Determine Python versions to test
-      - id: version-interpolator
+        id: version-interpolator
         run: |
           if [ ! ${{ inputs.skip_38 }} = true ]; then PY38='"3.8", '; else PY38=''; fi
-          if [ ${{ inputs.include_313 }} = true ]; then PY313='", 3.13"'; else PY313=''; fi
-          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]' $PY38 $PY313) >> $GITHUB_OUTPUT
+          if [ ${{ inputs.include_313 }} = true ]; then PY313=', "3.13"'; else PY313=''; fi
+          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]' "$PY38" "$PY313" >> $GITHUB_OUTPUT
   run-tests:
     name: Execute unit tests
     needs: matrix-prep

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,6 @@ jobs:
   matrix-prep:
     runs-on: ubuntu-latest
     outputs:
-<<<<<<< HEAD
       versions: ${{ steps.interpolator.outputs.versions }}
     steps:
       - name: Determine Python versions to test
@@ -34,27 +33,13 @@ jobs:
           printf 'versions=[%s"3.9", "3.10", "3.11", "3.12"%s]\n' "$PY38" "$PY313" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
-=======
-      python-version: ${{ steps.version-interpolator.outputs.python-version }}
-    steps:
-      - name: Determine Python versions to test
-      - id: version-interpolator
-        run: |
-          if [ ! ${{ inputs.skip_38 }} = true ]; then PY38='"3.8", '; else PY38=''; fi
-          if [ ${{ inputs.include_313 }} = true ]; then PY313='", 3.13"'; else PY313=''; fi
-          printf 'python-version=[%s"3.9", "3.10", "3.11", "3.12"%s]' $PY38 $PY313) >> $GITHUB_OUTPUT
->>>>>>> c488e9ce36417a4ddd5e33a055ca87a7d7905f91
   run-tests:
     name: Execute unit tests
     needs: matrix-prep
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         python-version: ${{ fromJson(needs.matrix-prep.outputs.versions) }}
-=======
-        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
->>>>>>> c488e9ce36417a4ddd5e33a055ca87a7d7905f91
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:
@@ -76,11 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         python-version: ${{ fromJson(needs.matrix-prep.outputs.versions) }}
-=======
-        python-version: ${{fromJson(needs.matrix_prep.outputs.python_version)}}
->>>>>>> c488e9ce36417a4ddd5e33a055ca87a7d7905f91
         runner-os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.runner-os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ It also kicks off a second run of tests in an environment where the dependency v
 #### inputs
 
 - src: The directory containing the repo's source code.
+- skip_38: If true, skip running tests on Python 3.8. Defaults to false.
+- include_313: If true, include Python 3.13 in the test matrix. Defaults to false.
 
 ### Deploy Documentation (deploy-docs.yml)
 


### PR DESCRIPTION
There was some unclear issue preventing the results of the matrix computation from being imported into the workflows.  This version runs tests as expected, as demonstrated here: 
https://github.com/CitrineInformatics/gemd-python/pull/225/checks