### PR TITLE
Update build command

### DIFF
--- a/deploy-template.yml
+++ b/deploy-template.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        run: pip install --upgrade build
+      - name: Build
+        run: python -m build --wheel --sdist
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Migrate the build task away from explicitly calling setup.py to using the build module.  This should support both setup.py and pyproject.toml packages.