### PR TITLE
Update to use absolute pathing

### DIFF
--- a/.github/actions/check-deprecations/action.yml
+++ b/.github/actions/check-deprecations/action.yml
@@ -16,7 +16,7 @@ runs:
     # must check out the repo at the workspace root (the default checkout path).
     - name: Extract current version
       id: current_version
-      uses: ./.github/actions/extract-version
+      uses: CitrineInformatics/common-gh-actions/.github/actions/extract-version@v3
       with:
         path: ${{ inputs.root }}
     - name: Check for expired deprecations

--- a/.github/actions/check-version-bump/action.yml
+++ b/.github/actions/check-version-bump/action.yml
@@ -17,12 +17,12 @@ runs:
     # version-bump job in repo-checks.yml for the expected checkout pattern.
     - name: Extract PR version
       id: pr_version
-      uses: ./.github/actions/extract-version
+      uses: CitrineInformatics/common-gh-actions/.github/actions/extract-version@v3
       with:
         path: ${{ inputs.pr_path }}
     - name: Extract main version
       id: main_version
-      uses: ./.github/actions/extract-version
+      uses: CitrineInformatics/common-gh-actions/.github/actions/extract-version@v3
       with:
         path: ${{ inputs.main_path }}
     - name: Verify version bump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "common-gh-actions"
-version = "3.0.0"
+version = "3.0.1"
 description = "Shared GitHub Actions and reusable workflows for Citrine's public Python repositories"
 requires-python = ">= 3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
At present, check-version-bump/action.yml and check-deprecations/action.yml reference extract-version/action.yml via a relative path.  This is a problem because consuming libraries try to resolve that locally.  This PR corrects that oversight.