### PR TITLE
Fix relative action refs in reusable workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Initialize the environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
         with:
           documentation: 'true'
       - name: Build Docs

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Simple checkout
         uses: actions/checkout@v6
       - name: Initialize the environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
       - name: Execute unit tests
         env:
           CITRINE_API_HOST: _TEST_HOST
@@ -128,7 +128,7 @@ jobs:
       - name: Simple checkout
         uses: actions/checkout@v6
       - name: Initialize the environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
         with:
           python_version: ${{ matrix.python-version }}
           resolution: lowest-direct
@@ -156,7 +156,7 @@ jobs:
       - name: Simple checkout
         uses: actions/checkout@v6
       - name: Initialize the environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
         with:
           python_version: ${{ matrix.python-version }}
           resolution: highest

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Simple checkout
         uses: actions/checkout@v6
       - name: Initialize development environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
       - name: Run ruff check
         run: uv run ruff check ${{ inputs.src }}
       - name: Run ruff format check
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Initialize the development environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
       - name: Lint the source directory
         run: uv run flake8 ${{ inputs.src }}
 
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Initialize the development environment
-        uses: ./.github/actions/initialize
+        uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
       - name: Run black format check
         run: uv run black --check ${{ inputs.src }}
 
@@ -108,7 +108,7 @@ jobs:
           ref: main
           path: main
       - name: Verify version bump
-        uses: ./.github/actions/check-version-bump
+        uses: CitrineInformatics/common-gh-actions/.github/actions/check-version-bump@v3
         with:
           pr_path: .
           main_path: main
@@ -121,6 +121,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v6
       - name: Check for expired deprecations
-        uses: ./.github/actions/check-deprecations
+        uses: CitrineInformatics/common-gh-actions/.github/actions/check-deprecations@v3
         with:
           src: ${{ inputs.src }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ Shared GitHub Actions and reusable workflows for CitrineInformatics Python repos
 - Action inputs use kebab-case; workflow inputs use snake_case
 - Action directories use kebab-case; Python scripts use matching snake_case names
 - Non-blocking jobs use `continue-on-error: true` and a "Non-blocking" name prefix
-- Local action refs (`./.github/actions/...`) are preferred over remote refs in reusable workflows — keeps action and workflow versions in sync
+- Reusable workflows (consumed via `workflow_call`) must use absolute action refs (`CitrineInformatics/common-gh-actions/.github/actions/...@v3`) so external consumers can resolve them
+- `local-pr.yml` is the only workflow that uses relative refs (`./.github/workflows/...`) since it runs CI for this repo itself
 - `workflow_call` inputs don't support enums — use a validation job with a `case` statement
 
 ## Key Design Decisions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "common-gh-actions"
-version = "3.0.1"
+version = "3.0.2"
 description = "Shared GitHub Actions and reusable workflows for Citrine's public Python repositories"
 requires-python = ">= 3.11"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "common-gh-actions"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary
- Reusable workflows (`repo-checks.yml`, `matrix-tests.yml`, `deploy-docs.yml`) used relative action refs (`./.github/actions/...`) which fail when external repos consume them via `workflow_call`
- Replaced all relative refs with absolute refs (`CitrineInformatics/common-gh-actions/.github/actions/...@v3`)
- Updated CLAUDE.md conventions to document this requirement
- `local-pr.yml` remains the only workflow using relative refs (it runs CI for this repo itself)

Fixes [PLA-14080](https://citrine.atlassian.net/browse/PLA-14080)

## Test plan
- [ ] Verify CI passes on this PR (`local-pr.yml` exercises the reusable workflows)
- [ ] Confirm a downstream repo can consume the updated workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLA-14080]: https://citrine.atlassian.net/browse/PLA-14080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ