### PR TITLE
Update intialize to use GitHub App

### DIFF
--- a/.github/actions/initialize/action.yml
+++ b/.github/actions/initialize/action.yml
@@ -19,6 +19,14 @@ inputs:
     description: 'If true, include the docs dependency group in uv sync'
     type: boolean
     default: false
+  app-id:
+    description: 'GitHub App ID for generating a token to access private repositories. If omitted, private repo access is not configured.'
+    required: false
+    default: ''
+  app-private-key:
+    description: 'GitHub App private key for generating a token to access private repositories. If omitted, private repo access is not configured.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -28,6 +36,18 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
+    - name: Generate app token
+      if: ${{ inputs.app-id != '' && inputs.app-private-key != '' }}
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+        owner: CitrineInformatics
+    - name: Update git to use CitrineInformatics token for repository access
+      if: ${{ steps.app-token.outputs.token != '' }}
+      run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+      shell: bash
     - name: Install uv
       uses: astral-sh/setup-uv@v7
     - name: Pin uv to the requested Python version

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,6 +27,8 @@ jobs:
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
         with:
           documentation: 'true'
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Build Docs
         run: |
           make -C docs/ html

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_311:
+        description: 'If true, omit Python 3.11 from the test matrix. Default: false'
+        required: false
+        type: boolean
+        default: false
       include_313:
         description: 'If true, include Python 3.13 in the test matrix. Default: true'
         required: false
@@ -71,6 +76,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Initialize the environment
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Execute unit tests
         env:
           CITRINE_API_HOST: _TEST_HOST
@@ -94,6 +102,7 @@ jobs:
               '3.8': '${{ inputs.skip_38 }}',
               '3.9': '${{ inputs.skip_39 }}',
               '3.10': '${{ inputs.skip_310 }}',
+              '3.11': '${{ inputs.skip_311 }}',
           }
           include = {
               '3.13': '${{ inputs.include_313 }}',
@@ -101,7 +110,7 @@ jobs:
               '3.15': '${{ inputs.include_315 }}',
           }
           versions = [v for v, s in skip.items() if s != 'true']
-          versions += ['3.11', '3.12']
+          versions += ['3.12']
           versions += [v for v, i in include.items() if i == 'true']
           runner_os = ['ubuntu-latest']
           if '${{ inputs.include_windows }}' == 'true':
@@ -132,6 +141,8 @@ jobs:
         with:
           python_version: ${{ matrix.python-version }}
           resolution: lowest-direct
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Execute unit tests
         env:
           CITRINE_API_HOST: _TEST_HOST
@@ -160,6 +171,8 @@ jobs:
         with:
           python_version: ${{ matrix.python-version }}
           resolution: highest
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Execute unit tests
         env:
           CITRINE_API_HOST: _TEST_HOST

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Initialize development environment
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Run ruff check
         run: uv run ruff check ${{ inputs.src }}
       - name: Run ruff format check
@@ -80,6 +83,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Initialize the development environment
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Lint the source directory
         run: uv run flake8 ${{ inputs.src }}
 
@@ -92,6 +98,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Initialize the development environment
         uses: CitrineInformatics/common-gh-actions/.github/actions/initialize@v3
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          app-private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Run black format check
         run: uv run black --check ${{ inputs.src }}
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,60 @@
 
 Shared GitHub Actions and reusable workflows for Citrine's Python repositories.
 
+## Quick Start
+
+To use these shared workflows in your repository, call them from a workflow file (e.g. `.github/workflows/pr.yml`):
+
+```yaml
+name: PR
+
+on:
+  pull_request:
+
+jobs:
+  checks:
+    uses: CitrineInformatics/common-gh-actions/.github/workflows/repo-checks.yml@v3
+    secrets: inherit
+    with:
+      src: src/my_package
+
+  tests:
+    uses: CitrineInformatics/common-gh-actions/.github/workflows/matrix-tests.yml@v3
+    secrets: inherit
+    with:
+      src: src/my_package
+```
+
+Pin to a major version tag (e.g. `@v3`) to receive non-breaking updates automatically.
+
+### Prerequisites
+
+If you want private repository access (i.e., your repository depends on another private repository for its testing), your repository must have the following **Actions secrets** configured:
+
+- `AUTOMATION_APP_ID` — The GitHub App ID
+- `AUTOMATION_APP_PRIVATE_KEY` — The GitHub App private key
+
+The `initialize` action will use them to generate a GitHub App token for private repository access.  Pass them to reusable workflows with `secrets: inherit`.
+
 ## Actions
 
 ### initialize
 
 Checks out the caller's repository, sets up Python (via `actions/setup-python`), and installs project dependencies using `uv`.
 
-Other Actions (`extract-version`, `check-version-bump`, `check-deprecations`) do **not** include checkout — callers must handle it themselves.  
+Other Actions (`extract-version`, `check-version-bump`, `check-deprecations`) do **not** include checkout — callers must handle it themselves.
 This is intentional so that build issues do not interfere with other checks.
 
 #### Inputs
 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
+| `app-id` | no | `""` | GitHub App ID for private repository access. If omitted, private repo access is not configured. |
+| `app-private-key` | no | `""` | GitHub App private key for private repository access. If omitted, private repo access is not configured. |
 | `python_version` | no | *(reads `.python-version`)* | Python version to install |
 | `resolution` | no | `""` | Passed to `uv --resolution` (`"highest"` or `"lowest-direct"`) |
-| `latest-citrine` | no | `true` | Install citrine from the main branch.  This is skipped if `resolution` is not `"highest"` or if the project itself *is* citrine-python (citrine is an editable dependency) |
-| `latest-gemd` | no | `true` | Install gemd from the main branch.  This is skipped if `resolution` is not `"highest"` or if the project itself *is* gemd-python (gemd is an editable dependency) |
+| `latest-citrine` | no | `true` | Install citrine from the main branch. Skipped if `resolution` is not `"highest"` or if the project itself *is* citrine-python (citrine is an editable dependency) |
+| `latest-gemd` | no | `true` | Install gemd from the main branch. Skipped if `resolution` is not `"highest"` or if the project itself *is* gemd-python (gemd is an editable dependency) |
 | `documentation` | no | `false` | Include the `docs` dependency group in `uv sync` |
 
 ### extract-version
@@ -89,8 +126,8 @@ Runs standard PR checks: linting, version bump verification, and deprecation sca
 ### matrix-tests.yml (PR Tests)
 
 Runs unit tests across a Python version / OS matrix, with coverage enforcement.
-Expects to run on Python 3.11 and 3.12 at a minimum.
-Coverage is only enforced on the pinned Python version.
+The default matrix includes Python 3.10–3.14; use the `skip_*` and `include_*` inputs to customize.
+Coverage is only enforced on the pinned Python version (run-tests-default job).
 
 #### Inputs
 
@@ -100,11 +137,12 @@ Coverage is only enforced on the pinned Python version.
 | `skip_38` | no | `true` | Omit Python 3.8 from the matrix |
 | `skip_39` | no | `true` | Omit Python 3.9 from the matrix |
 | `skip_310` | no | `false` | Omit Python 3.10 from the matrix |
+| `skip_311` | no | `false` | Omit Python 3.11 from the matrix |
 | `include_313` | no | `true` | Include Python 3.13 in the matrix |
 | `include_314` | no | `true` | Include Python 3.14 in the matrix |
 | `include_315` | no | `false` | Include Python 3.15 in the matrix |
 | `coverage_fails_under` | no | `100` | Minimum required coverage percentage |
-| `branch_coverage` | no | `false` | Include `--cov-branch` in coverage flags |
+| `branch_coverage` | no | `false` | Include `--cov-branch` in coverage flags at the percentage provided |
 | `include_windows` | no | `true` | Include windows-latest in the test matrix |
 | `include_macos` | no | `true` | Include macos-latest in the test matrix |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "common-gh-actions"
-version = "3.0.2"
+version = "3.0.3"
 description = "Shared GitHub Actions and reusable workflows for Citrine's public Python repositories"
 requires-python = ">= 3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR updates the workflow so that if a consuming repository needs access to a private repository for its testing, it can generate a token to get access.

This PR also moves Python 3.11 into the list of Python versions a consumer can opt out of, as we presently have a number of repositories that are 3.12 only.