### PR TITLE
Add uv.lock consistency check to repo-checks.yml

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: true
+      check_uv_lock:
+        description: 'If true, verify that uv.lock is in sync with pyproject.toml.'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -133,3 +138,18 @@ jobs:
         uses: CitrineInformatics/common-gh-actions/.github/actions/check-deprecations@v3
         with:
           src: ${{ inputs.src }}
+
+  uv-lock-check:
+    name: Verify uv.lock is up to date
+    if: ${{ inputs.check_uv_lock }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      # A stale lock forces `uv sync` to re-resolve, which fails in lanes
+      # without git auth when the lockfile references private git sources.
+      # `uv lock --check` exits non-zero on a stale lock without modifying it.
+      - name: Verify lockfile matches pyproject.toml
+        run: uv lock --check

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Scans Python source files for `@deprecation.deprecated` decorators and `warnings
 
 ### repo-checks.yml (PR Checks)
 
-Runs standard PR checks: linting, version bump verification, and deprecation scanning.
+Runs standard PR checks: linting, version bump verification, deprecation scanning, and uv.lock consistency.
 
 #### Inputs
 
@@ -112,6 +112,7 @@ Runs standard PR checks: linting, version bump verification, and deprecation sca
 | `linter` | no | `"ruff"` | Which linter to run. Must be one of: `ruff`, `flake8`, `black`, `none` |
 | `check_version_bump` | no | `true` | Verify the version in `pyproject.toml` has been incremented |
 | `check_deprecation` | no | `true` | Check for expired deprecations |
+| `check_uv_lock` | no | `true` | Verify `uv.lock` is in sync with `pyproject.toml` |
 
 #### Jobs
 
@@ -122,6 +123,7 @@ Runs standard PR checks: linting, version bump verification, and deprecation sca
 - **linting-black** -- `black --check` formatting check (when `linter` is `black`).
 - **version-bump** -- Compares PR vs. main version (skippable).
 - **deprecation-check** -- Scans for expired deprecations (skippable).
+- **uv-lock-check** -- Runs `uv lock --check` to verify `uv.lock` matches `pyproject.toml` (skippable).
 
 ### matrix-tests.yml (PR Tests)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "common-gh-actions"
-version = "3.0.3"
+version = "3.0.4"
 description = "Shared GitHub Actions and reusable workflows for Citrine's public Python repositories"
 requires-python = ">= 3.11"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "common-gh-actions"
-version = "3.0.1"
+version = "3.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

Adds a `uv-lock-check` job and a `check_uv_lock` toggle (default `true`) to the `repo-checks.yml` reusable workflow, mirroring `check_version_bump` and `check_deprecation`. The job runs `uv lock --check` to verify `uv.lock` is in sync with `pyproject.toml`.

Ironically, this repo's own `uv.lock` had drifted (`3.0.1` vs `pyproject` `3.0.3`).

## Changes

- `repo-checks.yml`: new `check_uv_lock` input (boolean, default `true`) and a `uv-lock-check` job gated on it, following the `check_version_bump` / `check_deprecation` pattern. The job body mirrors `linting-latest` (checkout + `setup-uv@v7`), with no token logic.
- README: documents the input and job in the `repo-checks.yml` section.
- Version bump `3.0.3` → `3.0.4`; regenerated `uv.lock` (corrects the pre-existing `3.0.1` drift).

## Test plan

- [x] `uv lock --check`
- [x] `uv run ruff check .github/actions tests`
- [x] `uv run pytest` — 85 passed
- [x] `repo-checks.yml` parses; inputs and jobs verified
- [x] CI green: repo-checks (incl. the new uv-lock-check job, which runs on this PR) and the full + latest test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
